### PR TITLE
🔧  Moves shared config out to sketch.config.json

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,12 +5,14 @@
  * @version 0.2
  */
 
+$config = json_decode( file_get_contents( './sketch.config.json' ) );
+
 // hook up with a live demo shop
 define ( 'SHOP_ID', '172820');
-define ( 'INDEX_PAGE', 'http://sketch.webshopapp.com/en/' );
+define ( 'INDEX_PAGE', $config->lightspeedUrl );
 
 // the base url from where your website is visible in the browser
-define( 'BASE_URL', 'http://localhost/sketch/' );
+define( 'BASE_URL', trailingslashit($config->localUrl) );
 
 // you can leave the rest 'as is' when not changing the directory structure
 define( 'ASSET_URL', BASE_URL . 'assets/' );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,38 +6,51 @@
 
 var gulp = require('gulp');
 var browserSync = require('browser-sync').create();
+var connect = require('gulp-connect-php');
 var sass = require('gulp-sass');
 var minify = require('gulp-minify');
 var flatten = require('gulp-flatten');
 var sourcemaps = require('gulp-sourcemaps');
-var rename = require("gulp-rename");
+var rename = require('gulp-rename');
 var csslint = require('gulp-csslint');
-var jshint = require("gulp-jshint");
+var jshint = require('gulp-jshint');
+var url = require('url');
 
-gulp.task('serve', function () {
-    browserSync.init({
-        proxy: "localhost:80/sketch",
-        port: 3001
-    });
+var Config = require('./sketch.config.json');
 
-    gulp.watch("build/scss/**/*.scss", ['sass']);
-    gulp.watch("build/js/**/*.js", ['scripts']);
-    gulp.watch("templates/**/*.rain").on('change', browserSync.reload);
+gulp.task('php', function() {
+    var localUrl = url.parse(Config.localUrl);
+
+    connect.server({
+        hostname: localUrl.hostname,
+        port: localUrl.port
+    }, () => {
+        browserSync.init({
+            proxy: Config.localUrl,
+            port: 3001
+        });
+   });
+})
+
+gulp.task('watch', function () {
+    gulp.watch('build/scss/**/*.scss', ['sass']);
+    gulp.watch('build/js/**/*.js', ['scripts']);
+    gulp.watch('templates/**/*.rain').on('change', browserSync.reload);
 });
 
 // Compile sass into CSS & auto-inject into browsers
 gulp.task('sass', function () {
-    return gulp.src("build/scss/**/*.scss")
+    return gulp.src('build/scss/**/*.scss')
         .pipe(flatten())
         .pipe(sass().on('error', sass.logError))
-        .pipe(gulp.dest("assets"))
+        .pipe(gulp.dest('assets'))
         .pipe(sourcemaps.init())
         .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
         .pipe(sourcemaps.write())
         .pipe(rename({
-            suffix: "-min"
+            suffix: '-min'
         }))
-        .pipe(gulp.dest("assets"))
+        .pipe(gulp.dest('assets'))
         .pipe(browserSync.stream());
 });
 
@@ -51,14 +64,14 @@ gulp.task('scripts', function () {
     gulp.src('build/js/**/*.js')
         .pipe(flatten())
         .pipe(minify())
-        .pipe(gulp.dest("assets"))
+        .pipe(gulp.dest('assets'))
         .pipe(browserSync.stream());
 });
 
-gulp.task("jshint", function () {
-    gulp.src("./assets/*.js")
+gulp.task('jshint', function () {
+    gulp.src('./assets/*.js')
         .pipe(jshint())
-        .pipe(jshint.reporter("default"));
+        .pipe(jshint.reporter('default'));
 });
 
-gulp.task('default', ['serve']);
+gulp.task('default', ['php', 'watch']);

--- a/includes/Helpers.php
+++ b/includes/Helpers.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+  * Appends a trailing slash.
+  *
+  * Will remove trailing forward and backslashes if it exists already before adding
+  * a trailing forward slash. This prevents double slashing a string or path.
+  *
+  * The primary use of this is for paths and thus should be used for paths. It is
+  * not restricted to paths and offers no specific path support.
+  *
+  * @param string $string What to add the trailing slash to.
+  * @return string String with trailing slash added.
+  */
+function trailingslashit( $string ) {
+        return untrailingslashit( $string ) . '/';
+}
+
+/**
+  * Removes trailing forward slashes and backslashes if they exist.
+  *
+  * The primary use of this is for paths and thus should be used for paths. It is
+  * not restricted to paths and offers no specific path support.
+  *
+  * @param string $string What to remove the trailing slashes from.
+  * @return string String without the trailing slashes.
+  */
+function untrailingslashit( $string ) {
+        return rtrim( $string, '/\\' );
+}

--- a/index.php
+++ b/index.php
@@ -5,11 +5,14 @@
  * @version 0.2
  */
 
+require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+require_once dirname( __FILE__ ) . '/includes/Helpers.php';
+require_once dirname( __FILE__ ) . '/includes/DrifterTwigExtension.php';
+
 require_once dirname( __FILE__ ) . '/config.php';
-require_once BASE_PATH . '/vendor/autoload.php';
+
 
 /* TODO add to autoload */
-require_once BASE_PATH . '/includes/DrifterTwigExtension.php';
 
 /* TODO create loader for stylesheets */
 $loader = new Twig_Loader_Filesystem( 'templates' );
@@ -42,7 +45,6 @@ if ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] != 'off' ) {
 $uri = '';
 if ( isset( $_GET['path'] ) ) {
 	$uri = $_GET['path'];
-
 }
 
 $templateData = file_get_contents( INDEX_PAGE . $uri . '?format=json' );

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Synopsis ==========",
   "main": "main.js",
   "dependencies": {
-    "browser-sync": "^2.11.1",
+    "browser-sync": "^2.18.8",
     "gulp": "^3.9.0",
+    "gulp-connect-php": "0.0.8",
     "gulp-flatten": "^0.3.0",
     "gulp-sass": "^2.2.0"
   },
@@ -18,7 +19,7 @@
     "jshint": "^2.9.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,41 +1,41 @@
-Synopsis
-==========
+Sketch
+===
 
-Sketch is used to create a local development environment for Lightspeed (formerly knows as SEOshop) themes. 
-Lightspeed uses the ".rain" language as a template engine, which is almost identical to the better known language "Twig". 
+Synopsis
+---
+
+Sketch is used to create a local development environment for Lightspeed (formerly knows as SEOshop) themes.
+Lightspeed uses the ".rain" language as a template engine, which is almost identical to the better known language "Twig".
+
 
 Requirements
-==========
+---
 
-- Composer
-- PHPserver  : The router currently only works with Apache. You can port the apache rules to Nginx in the location block (will provide snippet for it soon)
-- Node.js
-- Gulp
+- [Composer](https://getcomposer.org/)
+- [PHP web server](http://php.net/manual/en/features.commandline.webserver.php): The router currently only works with Apache. You can port the apache rules to Nginx in the location block (will provide snippet for it soon)
+- [Node.js](https://nodejs.org/en/)
+- [Gulp](http://gulpjs.com/)
+
 
 Installation
-==========
+---
 
-- fire up your webserver
-- Create a folder that is accessible by your webserver
-- Download Sketch `git clone https://github.com/Willemdumee/Sketch.git .` 
-- Run `composer install` in terminal
-- Run `npm install` in terminal
-- Define 'base url' inside 'config.php' (e.g. http://localhost/myawesomeshop)
-- Change gulpfile.js line 19 `proxy: localhost:80/sketch` to the base url which you also defined above
-- Run `gulp` in terminal
+- Clone the Sketch repo `git clone https://github.com/Willemdumee/Sketch.git`
+- Change into the cloned directory and run `npm install && composer install` in terminal.
+- Update `sketch.config.json`, so that 'lightspeedUrl' matches your store's URL.
+- Run `npm start` in terminal
 
 In order to use browsersync: open url in browser with portnumber 3001 ( e.g. localhost:3001/sketch )
 
 
 Connect to your own Lightspeed shop
-==========
+---
 
 - Create a Lightspeed shop (and create at least 1 product, 1 collection, 1 category, 1 product, 1 brand, 1 tag and 1 text page)
-- Change 'config.php' to connect to your Lightspeed shop. You should define the url to
-  * Index page
+- Change `sketch.config.json` to connect to your Lightspeed shop. This should be equal to the index page.
 
 License
-==========
+---
 
 MIT
 

--- a/sketch.config.json
+++ b/sketch.config.json
@@ -1,0 +1,4 @@
+{
+  "lightspeedUrl": "http://example.webshopapp.com/en",
+  "localUrl": "http://127.0.0.1:8002"
+}


### PR DESCRIPTION
Attempts to simplify the config process, so that PHP/Gulp use .json file as point of reference.

Also:
* Launch PHP server from within gulp task
* Adds `npm start` script to launch 
* Include `trailingslashit` helpers to normalise localUrl

Let me know if you'd prefer this split into separate PRs